### PR TITLE
Improve animation performance

### DIFF
--- a/src/page.module.css
+++ b/src/page.module.css
@@ -30,6 +30,7 @@
   filter: blur(35px);
   opacity: 0;
   transition: opacity 1s ease;
+  will-change: opacity;
   z-index: 1;
 }
 
@@ -47,6 +48,7 @@
   z-index: 10;
   transition: transform 0.5s ease;
   transform-origin: center;
+  will-change: transform;
 }
 
 .imageLayer {
@@ -56,9 +58,16 @@
   justify-content: center;
   align-items: center;
   transition: opacity 1s ease;
+  will-change: opacity;
 }
 
-.albumImage { width: 100%; height: 100%; object-fit: fill; border-radius: 12px;}
+.albumImage {
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  border-radius: 12px;
+  backface-visibility: hidden;
+}
 
 .topLayer { z-index: 2; opacity: 1; }
 .bottomLayer { z-index: 1; opacity: 0; }


### PR DESCRIPTION
## Summary
- hint the browser to optimize transforms and opacity with `will-change`
- hide the backface of album images to reduce rendering cost

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686127501c8c832da84a9e11738f1ced